### PR TITLE
Fixed magic debuffs not displaying for shamans on initial load

### DIFF
--- a/HealBot/HealBot_Options.lua
+++ b/HealBot/HealBot_Options.lua
@@ -7430,6 +7430,7 @@ end
 
 local FirstDebuffLoad=true
 function HealBot_Options_Debuff_Reset()
+    HealBot_Options_setDebuffTypes()
     HealBot_SetAuraChecks()
     HealBot_DebuffWatchTarget[HEALBOT_DISEASE_en] = {HEALBOT_DISEASE_en = {}};
     HealBot_DebuffWatchTarget[HEALBOT_POISON_en] = {HEALBOT_POISON_en = {}};

--- a/HealBot/HealBot_Options.lua
+++ b/HealBot/HealBot_Options.lua
@@ -7649,6 +7649,7 @@ end
 local spells={}
 local FirstBuffLoad=true
 function HealBot_Options_Buff_Reset()
+    HealBot_Options_setDebuffTypes()
     HealBot_SetAuraChecks()
     BuffTextClass = HealBot_Config_Buffs.HealBotBuffText
     local BuffDropDownClass = HealBot_Config_Buffs.HealBotBuffDropDown


### PR DESCRIPTION
Fixed magic debuffs not displaying for shamans on initial load (thanks to Larok)
