### PR TITLE
Fixed Raid Combat Protection

### DIFF
--- a/HealBot/HealBot.lua
+++ b/HealBot/HealBot.lua
@@ -3780,7 +3780,7 @@ function HealBot_CheckUnitBuffs(button)
                 local getCD = false
                 if HealBot_BuffWatch[k]~=HEALBOT_EVER_BLOOMING_FROND then
                     getCD = true
-                elseif not IsInRaid() then
+                elseif not IsInRaid() and not UnitAffectingCombat("player") then
                     getCD = true
                     local mPct, hPct = 100, 100
                     local mana,maxmana=HealBot_UnitMana(xUnit)


### PR DESCRIPTION
Fixed Raid Combat Protection not working
Changed Raid Combat Protection to fill empty group slots first
Changed Ever Blooming Frond to not monitor when player is in combat
