### PR TITLE
Fix 7.1 occasional UNIT_HEALTH nil

### DIFF
--- a/HealBot/HealBot.lua
+++ b/HealBot/HealBot.lua
@@ -1824,7 +1824,7 @@ function HealBot_OnEvent(self, event, ...)
     elseif (event=="UNIT_AURA") then
         HealBot_OnEvent_UnitAura(self,arg1);
     elseif (event=="UNIT_HEALTH") or (event=="UNIT_MAXHEALTH") then
-        HealBot_OnEvent_UnitHealth(true,arg1,UnitHealth(arg1),HealBot_UnitMaxHealth(arg1));
+        if (arg1) then HealBot_OnEvent_UnitHealth(true,arg1,UnitHealth(arg1),HealBot_UnitMaxHealth(arg1)); end
     elseif (event=="UNIT_COMBAT") then 
         if arg1 then HealBot_OnEvent_UnitCombat(arg1); end
     elseif (event=="UNIT_THREAT_SITUATION_UPDATE") or (event=="UNIT_THREAT_LIST_UPDATE") then


### PR DESCRIPTION
It looks like since 7.1 the UNIT_HEALTH or UNIT_MAXHEALTH events will occasionally provide `nil` as the value of `arg1`.  This PR is a basic, hack-and-slash fix for that that should at least prevent the deluge of errors that this causes.

Is it the right fix?  I don't know.  Does it have side effects?  I also don't know.  Buuuuuut, it makes things usable again for me, so I figured I'd PR it up to the mainline anyway :)
