### PR TITLE
Hotfix Dispell Magic (Rank 2) for PRIE

### DIFF
--- a/HealBot/HealBot_Options.lua
+++ b/HealBot/HealBot_Options.lua
@@ -945,7 +945,7 @@ function HealBot_Options_GetDebuffSpells_List(class)
           ["MAGE"] = {HEALBOT_REMOVE_CURSE,},
           ["MONK"] = {},
           ["PALA"] = {HEALBOT_CLEANSE, HBC_PURIFY},
-          ["PRIE"] = {HBC_DISPELL_MAGIC, HBC_PRIEST_CURE_DISEASE, HBC_PRIEST_ABOLISH_DISEASE},
+          ["PRIE"] = {HBC_DISPELL_MAGIC, HBC_DISPELL_MAGIC_RANK_2, HBC_PRIEST_CURE_DISEASE, HBC_PRIEST_ABOLISH_DISEASE},
           ["ROGU"] = {},
           ["SHAM"] = {HBC_SHAMAN_CURE_POISON, HBC_SHAMAN_CURE_DISEASE},
           ["WARL"] = {},

--- a/HealBot/Locale/HealBot_Global.lua
+++ b/HealBot/Locale/HealBot_Global.lua
@@ -591,6 +591,7 @@ function HealBot_globalVars()
     HBC_PRIEST_CURE_DISEASE                 = 528
     HBC_PRIEST_ABOLISH_DISEASE              = 552
     HBC_DISPELL_MAGIC                       = 527
+    HBC_DISPELL_MAGIC_RANK_2                = 988
     HBC_SHAMAN_CURE_POISON                  = 526
     HBC_DRUID_CURE_POISON                   = 8946
     HBC_DRUID_ABOLISH_POISON                = 2893


### PR DESCRIPTION
Reference: https://healbot.dpm15.net/forum/bug-c/491-debuffs-not-showing-up

Add Dispell Magic (Rank 2) spell to the Debuff checker

Not sure if correct fix but at least hotfix for classic wow

