### PR TITLE
fix: added dependency links

### DIFF
--- a/HealBot_Data/HealBot_Data.toc
+++ b/HealBot_Data/HealBot_Data.toc
@@ -5,6 +5,7 @@
 ## RequiredDeps: HealBot_en
 ## SavedVariablesPerCharacter:  HealBot_Config, HealBot_Config_Spells, HealBot_Config_Buffs, HealBot_Config_Cures
 ## SavedVariables: Healbot_Config_Skins, HealBot_Globals, HealBot_Class_Spells, HealBot_Class_Buffs, HealBot_Class_Cures
+## RequiredDeps: HealBot
 ## Version: 8.3.7.0
 
 HealBot_Data.lua

--- a/HealBot_Data/HealBot_Data.toc
+++ b/HealBot_Data/HealBot_Data.toc
@@ -5,7 +5,6 @@
 ## RequiredDeps: HealBot_en
 ## SavedVariablesPerCharacter:  HealBot_Config, HealBot_Config_Spells, HealBot_Config_Buffs, HealBot_Config_Cures
 ## SavedVariables: Healbot_Config_Skins, HealBot_Globals, HealBot_Class_Spells, HealBot_Class_Buffs, HealBot_Class_Cures
-## RequiredDeps: HealBot
 ## Version: 8.3.7.0
 
 HealBot_Data.lua

--- a/HealBot_en/HealBot_en.toc
+++ b/HealBot_en/HealBot_en.toc
@@ -2,6 +2,7 @@
 ## Title: HealBot English Localization
 ## Author: Strife
 ## Notes: HealBot localization for enUS and enUK
+## RequiredDeps: HealBot
 ## Version: 8.3.7.0
 
 Libs\LibStub\LibStub.lua


### PR DESCRIPTION
Hello,

I am currently creating a [Addon Manager](https://github.com/casperstorm/ajour/) and while parsing the `.toc` files I've noticed that some of your sub-folders didn't have the dependency link to `HealBot`: `## RequiredDeps: HealBot`

I have fixed this issue for you. This also means that in my addon manager HealBot will only be shown as 1 addon instead of multiple (those without the dependency link).