### PR TITLE
Fix low mana indicators not being removed when mana increased

### DIFF
--- a/HealBot/HealBot.lua
+++ b/HealBot/HealBot.lua
@@ -1094,9 +1094,6 @@ function HealBot_UnitMana(button)
             if not HealBot_Data["UILOCK"] and HEALBOT_GAME_VERSION<5 and button.isplayer and not button.player and (hbManaMax>(button.mana.max*1.25) or hbManaMax<(button.mana.max*0.75)) then
                 HealBot_Events_SpecChange(button)
             end
-            if hbManaCurrent < button.mana.current then
-                button.mana.lowcheck=true
-            end
             button.mana.current=hbManaCurrent
             button.mana.max=hbManaMax
             if button.mana.max>0 then
@@ -1127,6 +1124,7 @@ function HealBot_UnitMana(button)
         HealBot_Aux_setPowerBars(button)
         HealBot_Events_PowerIndicators(button)
     end
+    button.mana.lowcheck=true
 end
 
 function HealBot_GetUnitGuild(button)


### PR DESCRIPTION
This reverts a change made about a month ago in order to fix low mana indicators not being removed when a unit gains mana back over a threshold. 

The current behavior is that this indicator is only updated when a unit's mana decreases, which leads to them not being removed after drinking or out-of-combat regen. This makes it difficult to know when others are ready.